### PR TITLE
feat: switch from op/go-logging to log/slog for structured logging

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -22,7 +22,7 @@ type Account struct {
 func (t *textGrid) CreateAccount(data url.Values) (*Account, error) {
 	result := new(Account)
 
-	if err := t.postForm("Accounts.json", data, result); err != nil {
+	if err := t.postForm("accounts.create", "Accounts.json", data, result); err != nil {
 		return nil, err
 	}
 

--- a/brand.go
+++ b/brand.go
@@ -131,7 +131,7 @@ var (
 func (t *textGrid) CreateBrand(brand CreateBrandPayload) (*Brand, error) {
 	result := new(Brand)
 
-	if err := t.post("campaigns/brand/nonblocking", brand, result); err != nil {
+	if err := t.post("brand.create", "campaigns/brand/nonblocking", brand, result); err != nil {
 		return nil, err
 	}
 
@@ -149,7 +149,7 @@ func (t *textGrid) CreateBrand(brand CreateBrandPayload) (*Brand, error) {
 func (t *textGrid) GetBrand(id string) (*Brand, error) {
 	resp := new(Brand)
 
-	if err := t.get("campaigns/brand/"+id, nil, resp); err != nil {
+	if err := t.get("brand.get", "campaigns/brand/"+id, nil, resp); err != nil {
 		return nil, err
 	}
 
@@ -158,5 +158,5 @@ func (t *textGrid) GetBrand(id string) (*Brand, error) {
 
 // DeleteBrand removes the brand, unless it has an active campaign
 func (t *textGrid) DeleteBrand(id string) error {
-	return t.delete("campaigns/brand/"+id, nil)
+	return t.delete("brand.delete", "campaigns/brand/"+id, nil)
 }

--- a/calls.go
+++ b/calls.go
@@ -36,7 +36,7 @@ func (t *textGrid) GetCall(id string) (*Call, error) {
 	//Accounts/kjuUgB7bAst7NP5425662JHOC09Q==/Calls/CAIGVOmFk1Rj~vlCEDKnVBNuQ==.json
 	endpoint := fmt.Sprintf("Accounts/%s/Calls/%s.json", t.AccountSid, id)
 
-	if err := t.get(endpoint, nil, result); err != nil {
+	if err := t.get("calls.get", endpoint, nil, result); err != nil {
 		return nil, err
 	}
 
@@ -49,7 +49,7 @@ func (t *textGrid) InitiateCall(call CallInitiatePayload) (*Call, error) {
 
 	endpoint := fmt.Sprintf("Accounts/%s/Calls.json", t.AccountSid)
 
-	if err := t.post(endpoint, call, result); err != nil {
+	if err := t.post("calls.initiate", endpoint, call, result); err != nil {
 		return nil, err
 	}
 

--- a/campaign.go
+++ b/campaign.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 )
 
@@ -98,7 +99,7 @@ var (
 func (t *textGrid) CreateCampaign(payload CreateCampaignPayload) (*Campaign, error) {
 	result := new(Campaign)
 
-	if err := t.post("campaigns/campaign", payload, result); err != nil {
+	if err := t.post("campaigns.create", "campaigns/campaign", payload, result); err != nil {
 		return nil, err
 	}
 
@@ -109,7 +110,7 @@ func (t *textGrid) CreateCampaign(payload CreateCampaignPayload) (*Campaign, err
 func (t *textGrid) GetCampaigns() ([]Campaign, error) {
 	result := make([]Campaign, 0)
 
-	if err := t.get("campaigns/campaign", nil, &result); err != nil {
+	if err := t.get("campaigns.list", "campaigns/campaign", nil, &result); err != nil {
 		return nil, err
 	}
 
@@ -120,7 +121,7 @@ func (t *textGrid) GetCampaigns() ([]Campaign, error) {
 func (t *textGrid) GetCampaign(id string) (*Campaign, error) {
 	result := new(Campaign)
 
-	if err := t.get("campaigns/campaign/"+id, nil, result); err != nil {
+	if err := t.get("campaigns.get", "campaigns/campaign/"+id, nil, result); err != nil {
 		return nil, err
 	}
 
@@ -128,7 +129,7 @@ func (t *textGrid) GetCampaign(id string) (*Campaign, error) {
 }
 
 func (t *textGrid) DeactivateCampaign(id string) error {
-	return t.delete("campaigns/campaign/"+id, nil)
+	return t.delete("campaigns.deactivate", "campaigns/campaign/"+id, nil)
 }
 
 type attachNumberToCampaign struct {
@@ -136,12 +137,18 @@ type attachNumberToCampaign struct {
 }
 
 func (t *textGrid) AttachNumberToCampaign(id, numberID string) error {
+	const op = "campaigns.attach_number"
+
 	payload := attachNumberToCampaign{
 		PhoneNumberSids: []string{numberID},
 	}
 
 	fullURL := t.generateFullUrl("campaigns/number/" + id)
-	log.Debugf("TextGrid POST %s", fullURL)
+	slog.Debug("textgrid POST",
+		slog.String("component", component),
+		slog.String("op", op),
+		slog.String("url", fullURL),
+	)
 
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -160,18 +167,37 @@ func (t *textGrid) AttachNumberToCampaign(id, numberID string) error {
 	// Use HTTP/1.1 client — TextGrid's campaigns/number endpoint rejects HTTP/2.
 	resp, err := http11Client.Do(req)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid request transport failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "POST"),
+			slog.Any("error", err),
+		)
 		return err
 	}
 	defer resp.Body.Close()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid response body read failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.Any("error", err),
+		)
 		return err
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		slog.Error("textgrid request returned non-2xx",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "POST"),
+			slog.Int("status_code", resp.StatusCode),
+			slog.String("body", string(data)),
+		)
 		return fmt.Errorf("non-200/201 status code %d returned from %s with body %s", resp.StatusCode, fullURL, data)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
 module github.com/Lendiom/go-textgrid
 
-go 1.18
+go 1.21
 
-require (
-	github.com/google/go-querystring v1.2.0
-	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
-)
+require github.com/google/go-querystring v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,3 @@ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
-github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=
-github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=

--- a/lookups.go
+++ b/lookups.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-
+	"log/slog"
 	"net/http"
 	"net/url"
 )
@@ -69,6 +69,8 @@ func (t *textGrid) Lookups() NumberLookup {
 }
 
 func (nl *numberLookup) Get(number string) (Lookup, error) {
+	const op = "lookups.get"
+
 	res := Lookup{}
 
 	params := url.Values{}
@@ -76,11 +78,21 @@ func (nl *numberLookup) Get(number string) (Lookup, error) {
 	params.Add("type", "caller-name")
 
 	fullURL := fmt.Sprintf("https://lookups.textgrid.com/v1/PhoneNumbers/%s", number) + queryParams(params)
-	log.Debugf("TextGrid GET %s", fullURL)
+	slog.Debug("textgrid GET",
+		slog.String("component", component),
+		slog.String("op", op),
+		slog.String("url", fullURL),
+	)
 
 	req, err := http.NewRequest("GET", fullURL, nil)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid request build failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "GET"),
+			slog.Any("error", err),
+		)
 		return res, err
 	}
 
@@ -89,14 +101,25 @@ func (nl *numberLookup) Get(number string) (Lookup, error) {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid request transport failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "GET"),
+			slog.Any("error", err),
+		)
 		return res, err
 	}
 	defer resp.Body.Close()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid response body read failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.Any("error", err),
+		)
 		return res, err
 	}
 
@@ -106,7 +129,14 @@ func (nl *numberLookup) Get(number string) (Lookup, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		err = fmt.Errorf("non-200 status code %d returned from %s with body %s", resp.StatusCode, fullURL, data)
-		logStackTrace(err)
+		slog.Error("textgrid request returned non-2xx",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "GET"),
+			slog.Int("status_code", resp.StatusCode),
+			slog.String("body", string(data)),
+		)
 		json.Unmarshal(data, &res) // try, anyway -- in case the caller wants error info
 		return res, err
 	}

--- a/messages.go
+++ b/messages.go
@@ -59,7 +59,7 @@ func (t *textGrid) GetMessage(id string) (*Message, error) {
 	//Accounts/kjuUgB7bAst7NP5425662JHOC09Q==/Messages/CAIGVOmFk1Rj~vlCEDKnVBNuQ==.json
 	endpoint := fmt.Sprintf("Accounts/%s/Messages/%s.json", t.AccountSid, id)
 
-	if err := t.get(endpoint, nil, result); err != nil {
+	if err := t.get("messages.get", endpoint, nil, result); err != nil {
 		return nil, err
 	}
 

--- a/numbers.go
+++ b/numbers.go
@@ -47,7 +47,7 @@ func (t *textGrid) ListAvailablePhoneNumbers(countryCode CountryCode, search Ava
 
 	urlPartial := fmt.Sprintf("Accounts/%s/AvailablePhoneNumbers/%s/Local.json", t.AccountSid, countryCode)
 
-	if err := t.get(urlPartial, vals, result); err != nil {
+	if err := t.get("numbers.list_available", urlPartial, vals, result); err != nil {
 		return nil, err
 	}
 
@@ -103,7 +103,7 @@ func (t *textGrid) AddIncomingPhoneNumber(payload AddIncomingPhoneNumberPayload)
 
 	urlPartial := fmt.Sprintf("Accounts/%s/IncomingPhoneNumbers.json", t.AccountSid)
 
-	if err := t.postForm(urlPartial, vals, result); err != nil {
+	if err := t.postForm("numbers.add_incoming", urlPartial, vals, result); err != nil {
 		return nil, err
 	}
 

--- a/optin.go
+++ b/optin.go
@@ -32,7 +32,7 @@ func (t *textGrid) GetOptInStatus(to, from string) (*OptInStatus, error) {
 	//optin/status/+19132401531/+16095363466
 	endpoint := fmt.Sprintf("optin/status/%s/%s", to, from)
 
-	if err := t.get(endpoint, nil, result); err != nil {
+	if err := t.get("optin.get_status", endpoint, nil, result); err != nil {
 		return nil, err
 	}
 

--- a/textgrid.go
+++ b/textgrid.go
@@ -6,26 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
-	"runtime"
 	"strings"
-
-	"github.com/op/go-logging"
 )
 
-var log = logging.MustGetLogger("textgrid")
-
-// LogStackTrace logs a stack trace for the given error.
-func logStackTrace(err error) {
-	buf := make([]byte, 0, 16384)
-	n := runtime.Stack(buf, false)
-	if err == nil {
-		log.Errorf("nil error; stack trace %s", buf[:n])
-	} else {
-		log.Errorf("non-nil error %s; stack trace %s", err.Error(), buf[:n])
-	}
-}
+const component = "go-textgrid"
 
 type TextGrid interface {
 	CreateAccount(data url.Values) (*Account, error)
@@ -88,13 +75,22 @@ func (t *textGrid) generateFullUrl(endpoint string) string {
 	return fmt.Sprintf("%s/%s/%s", t.BaseAPI, APIVersion, endpoint)
 }
 
-func (t *textGrid) post(endpoint string, payload, returnValue interface{}) error {
+func (t *textGrid) post(op, endpoint string, payload, returnValue interface{}) error {
 	fullURL := t.generateFullUrl(endpoint)
-	log.Debugf("TextGrid POST %s", fullURL)
+	slog.Debug("textgrid POST",
+		slog.String("component", component),
+		slog.String("op", op),
+		slog.String("url", fullURL),
+	)
 
 	body, err := json.Marshal(payload)
 	if err != nil {
-		log.Debugf("Failed to marshal the payload: %+v", payload)
+		slog.Error("textgrid request failed to marshal payload",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.Any("error", err),
+		)
 		return err
 	}
 
@@ -112,14 +108,25 @@ func (t *textGrid) post(endpoint string, payload, returnValue interface{}) error
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid request transport failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "POST"),
+			slog.Any("error", err),
+		)
 		return err
 	}
 	defer resp.Body.Close()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid response body read failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.Any("error", err),
+		)
 		return err
 	}
 
@@ -143,7 +150,14 @@ func (t *textGrid) post(endpoint string, payload, returnValue interface{}) error
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		err = fmt.Errorf("non-200/201 status code %d returned from %s with body %s", resp.StatusCode, fullURL, data)
-		logStackTrace(err)
+		slog.Error("textgrid request returned non-2xx",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "POST"),
+			slog.Int("status_code", resp.StatusCode),
+			slog.String("body", string(data)),
+		)
 		json.Unmarshal(data, returnValue) // try, anyway -- in case the caller wants error info
 		return err
 	}
@@ -156,9 +170,13 @@ func (t *textGrid) post(endpoint string, payload, returnValue interface{}) error
 	return json.Unmarshal(data, returnValue)
 }
 
-func (t *textGrid) postForm(endpoint string, payload url.Values, returnValue interface{}) error {
+func (t *textGrid) postForm(op, endpoint string, payload url.Values, returnValue interface{}) error {
 	fullURL := t.generateFullUrl(endpoint)
-	log.Debugf("TextGrid POST form %s", fullURL)
+	slog.Debug("textgrid POST form",
+		slog.String("component", component),
+		slog.String("op", op),
+		slog.String("url", fullURL),
+	)
 
 	req, err := http.NewRequest("POST", fullURL, strings.NewReader(payload.Encode()))
 	if err != nil {
@@ -171,14 +189,25 @@ func (t *textGrid) postForm(endpoint string, payload url.Values, returnValue int
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid request transport failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "POST"),
+			slog.Any("error", err),
+		)
 		return err
 	}
 	defer resp.Body.Close()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid response body read failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.Any("error", err),
+		)
 		return err
 	}
 
@@ -202,7 +231,14 @@ func (t *textGrid) postForm(endpoint string, payload url.Values, returnValue int
 
 	if resp.StatusCode != http.StatusOK {
 		err = fmt.Errorf("non-200 status code %d returned from %s with body %s", resp.StatusCode, fullURL, data)
-		logStackTrace(err)
+		slog.Error("textgrid request returned non-2xx",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "POST"),
+			slog.Int("status_code", resp.StatusCode),
+			slog.String("body", string(data)),
+		)
 		json.Unmarshal(data, returnValue) // try, anyway -- in case the caller wants error info
 		return err
 	}
@@ -210,12 +246,22 @@ func (t *textGrid) postForm(endpoint string, payload url.Values, returnValue int
 	return json.Unmarshal(data, returnValue)
 }
 
-func (t *textGrid) get(endpoint string, params url.Values, returnValue interface{}) error {
+func (t *textGrid) get(op, endpoint string, params url.Values, returnValue interface{}) error {
 	fullURL := t.generateFullUrl(endpoint) + queryParams(params)
-	log.Debugf("TextGrid GET %s", fullURL)
+	slog.Debug("textgrid GET",
+		slog.String("component", component),
+		slog.String("op", op),
+		slog.String("url", fullURL),
+	)
 	req, err := http.NewRequest("GET", fullURL, nil)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid request build failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "GET"),
+			slog.Any("error", err),
+		)
 		return err
 	}
 
@@ -224,20 +270,38 @@ func (t *textGrid) get(endpoint string, params url.Values, returnValue interface
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid request transport failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "GET"),
+			slog.Any("error", err),
+		)
 		return err
 	}
 	defer resp.Body.Close()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid response body read failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.Any("error", err),
+		)
 		return err
 	}
 
 	if resp.StatusCode != 200 {
 		err = fmt.Errorf("non-200 status code %d returned from %s with body %s", resp.StatusCode, fullURL, data)
-		logStackTrace(err)
+		slog.Error("textgrid request returned non-2xx",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "GET"),
+			slog.Int("status_code", resp.StatusCode),
+			slog.String("body", string(data)),
+		)
 		json.Unmarshal(data, returnValue) // try, anyway -- in case the caller wants error info
 		return err
 	}
@@ -245,12 +309,22 @@ func (t *textGrid) get(endpoint string, params url.Values, returnValue interface
 	return json.Unmarshal(data, returnValue)
 }
 
-func (t *textGrid) delete(endpoint string, params url.Values) error {
+func (t *textGrid) delete(op, endpoint string, params url.Values) error {
 	fullURL := t.generateFullUrl(endpoint) + queryParams(params)
-	log.Debugf("TextGrid DELETE %s", fullURL)
+	slog.Debug("textgrid DELETE",
+		slog.String("component", component),
+		slog.String("op", op),
+		slog.String("url", fullURL),
+	)
 	req, err := http.NewRequest("DELETE", fullURL, nil)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid request build failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "DELETE"),
+			slog.Any("error", err),
+		)
 		return err
 	}
 
@@ -259,20 +333,38 @@ func (t *textGrid) delete(endpoint string, params url.Values) error {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid request transport failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "DELETE"),
+			slog.Any("error", err),
+		)
 		return err
 	}
 	defer resp.Body.Close()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logStackTrace(err)
+		slog.Error("textgrid response body read failure",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.Any("error", err),
+		)
 		return err
 	}
 
 	if resp.StatusCode != 204 {
 		err = fmt.Errorf("non-204 status code %d returned from %s with body %s", resp.StatusCode, fullURL, data)
-		logStackTrace(err)
+		slog.Error("textgrid request returned non-2xx",
+			slog.String("component", component),
+			slog.String("op", op),
+			slog.String("url", fullURL),
+			slog.String("method", "DELETE"),
+			slog.Int("status_code", resp.StatusCode),
+			slog.String("body", string(data)),
+		)
 		return err
 	}
 


### PR DESCRIPTION
## Summary

Replace the package-level \`op/go-logging\` logger with direct \`log/slog\` calls. Every log event now carries \`component=go-textgrid\` plus a per-operation \`op\` so consumers can pivot on those attrs in their slog handler instead of grepping the free-text \`msg\` field.

## What changed

- **No more \`op/go-logging\`.** Dropped the package-level \`var log = logging.MustGetLogger(\"textgrid\")\` and removed \`github.com/op/go-logging\` from \`require\` / \`go.sum\`.
- **\`component\` + \`op\` on every event.** \`component=go-textgrid\`; \`op\` values follow \`<area>.<verb>\` — \`accounts.create\`, \`brand.create|get|delete\`, \`calls.get|initiate\`, \`campaigns.create|list|get|deactivate|attach_number\`, \`messages.get\`, \`numbers.list_available|add_incoming\`, \`optin.get_status\`, \`lookups.get\`.
- **Stack-trace flood removed.** \`logStackTrace\` (\`runtime.Stack\` + \`log.Errorf\`) is gone. It existed to attach call-site context to op/go-logging (which doesn't capture source info) but produced a stack dump on every expected non-2xx — including the 404 \`lookups\` returns when a number has no record. Routine non-2xx responses now emit a single structured \`textgrid request returned non-2xx\` event with \`method\`, \`status_code\`, \`body\`, and \`url\` as discrete attributes; consumers that want source info can enable \`AddSource\` on their slog handler.
- **Module updates:** \`go\` directive bumped from 1.18 → 1.21 (\`log/slog\` requires it). \`go.sum\` shrank by one entry.

## Internal API change (unexported)

\`post\` / \`postForm\` / \`get\` / \`delete\` each gained an \`op string\` first parameter so the http layer records the high-level operation. All in-package callers (\`accounts.go\`, \`brand.go\`, \`calls.go\`, \`campaign.go\`, \`messages.go\`, \`numbers.go\`, \`optin.go\`) were updated. The exported \`TextGrid\` interface, type signatures, and sentinel errors (\`ErrNumberNotFound\`) are unchanged.

## Consumer note

[landpro-server](https://github.com/FideTech/landpro-server) calls \`silenceThirdPartyLoggers()\` at startup, which raises op/go-logging's \"textgrid\" channel to \`CRITICAL\` to mute the stack-trace flood. After this PR that call is a no-op for this library — the equivalent suppression should move to a slog handler filter on \`component=go-textgrid\` (or be deleted, since the underlying noise is gone).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` passes (no test files in package)
- [x] \`gofmt -d\` clean on all changed \`.go\` files (pre-existing CRLF noise unchanged on files with single-line edits)
- [x] No remaining \`op/go-logging\` import in any source file

🤖 Generated with [Claude Code](https://claude.com/claude-code)