### PR TITLE
fix(logger): downgrade non-2xx response logs from Error to Debug

### DIFF
--- a/campaign.go
+++ b/campaign.go
@@ -190,7 +190,7 @@ func (t *textGrid) AttachNumberToCampaign(id, numberID string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		slog.Error("textgrid request returned non-2xx",
+		slog.Debug("textgrid request returned non-2xx",
 			slog.String("component", component),
 			slog.String("op", op),
 			slog.String("url", fullURL),

--- a/lookups.go
+++ b/lookups.go
@@ -129,7 +129,7 @@ func (nl *numberLookup) Get(number string) (Lookup, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		err = fmt.Errorf("non-200 status code %d returned from %s with body %s", resp.StatusCode, fullURL, data)
-		slog.Error("textgrid request returned non-2xx",
+		slog.Debug("textgrid request returned non-2xx",
 			slog.String("component", component),
 			slog.String("op", op),
 			slog.String("url", fullURL),

--- a/textgrid.go
+++ b/textgrid.go
@@ -150,7 +150,7 @@ func (t *textGrid) post(op, endpoint string, payload, returnValue interface{}) e
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		err = fmt.Errorf("non-200/201 status code %d returned from %s with body %s", resp.StatusCode, fullURL, data)
-		slog.Error("textgrid request returned non-2xx",
+		slog.Debug("textgrid request returned non-2xx",
 			slog.String("component", component),
 			slog.String("op", op),
 			slog.String("url", fullURL),
@@ -231,7 +231,7 @@ func (t *textGrid) postForm(op, endpoint string, payload url.Values, returnValue
 
 	if resp.StatusCode != http.StatusOK {
 		err = fmt.Errorf("non-200 status code %d returned from %s with body %s", resp.StatusCode, fullURL, data)
-		slog.Error("textgrid request returned non-2xx",
+		slog.Debug("textgrid request returned non-2xx",
 			slog.String("component", component),
 			slog.String("op", op),
 			slog.String("url", fullURL),
@@ -294,7 +294,7 @@ func (t *textGrid) get(op, endpoint string, params url.Values, returnValue inter
 
 	if resp.StatusCode != 200 {
 		err = fmt.Errorf("non-200 status code %d returned from %s with body %s", resp.StatusCode, fullURL, data)
-		slog.Error("textgrid request returned non-2xx",
+		slog.Debug("textgrid request returned non-2xx",
 			slog.String("component", component),
 			slog.String("op", op),
 			slog.String("url", fullURL),
@@ -357,7 +357,7 @@ func (t *textGrid) delete(op, endpoint string, params url.Values) error {
 
 	if resp.StatusCode != 204 {
 		err = fmt.Errorf("non-204 status code %d returned from %s with body %s", resp.StatusCode, fullURL, data)
-		slog.Error("textgrid request returned non-2xx",
+		slog.Debug("textgrid request returned non-2xx",
 			slog.String("component", component),
 			slog.String("op", op),
 			slog.String("url", fullURL),


### PR DESCRIPTION
## Summary

The HTTP helpers in `textgrid.go`, `campaign.go`, and `lookups.go` log every non-2xx response at `slog.Error` before returning. The returned error already carries the status code, URL, and body verbatim, so each non-2xx outcome is logged twice: once at library Error level without business context (no `trace_id`, no `auth_context`, no domain IDs), and again at whatever level the caller decided was appropriate after inspecting the returned error.

The status-code classification belongs to the caller. A 404 on `optin/status` means \"no opt-in record yet\" (the normal state for any number that has not been through START/STOP), while a 404 on another endpoint may be a genuine error. The library is in no position to make that call without context.

## Changes

Downgrade the six \`slog.Error(\"textgrid request returned non-2xx\", ...)\` calls to \`slog.Debug\` across:
- `textgrid.go` (POST / POST-form / GET / DELETE helpers — 4 sites)
- `campaign.go` (custom POST flow — 1 site)
- `lookups.go` (custom GET flow — 1 site)

Genuine library-side failures (transport, body-read, build, payload-marshal) keep logging at Error because the caller has no visibility into them.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] Tag a release after merge and bump landpro-server's `go.mod` — verify the 24h scheduler ERROR count drops to 0 for the matching pattern